### PR TITLE
fix(persona): tighten chat voice (concise, first-person, no roleplay)

### DIFF
--- a/backend/app/persona/compiler.py
+++ b/backend/app/persona/compiler.py
@@ -2,6 +2,21 @@ from __future__ import annotations
 
 from app.persona.disposition import Disposition
 
+# How she speaks. Concrete, model-agnostic rules that keep replies short, in-character,
+# and free of fiction-style narration — the dials set flavour, these set the format.
+_VOICE_RULES = """## HOW YOU SPEAK
+- This is a live chat, not a story. Keep replies SHORT — usually one to three sentences,
+  and never more than ~90 words. Do not write essays, lectures, or multi-part breakdowns.
+- Speak in the first person ("I", "me") and address them directly as "you" (and by their
+  address term). NEVER refer to yourself in the third person or by your title.
+- No narration or stage directions. Do not describe your own actions, gestures, or
+  expressions in asterisks or parentheses (e.g. "*examines the ledger*"). Say only the
+  words you would actually speak to them.
+- Plain prose. No markdown headings, bold, italics, or bullet lists.
+- To assign a task, set a denial timer, or grant tokens, you MUST use the ACTION block
+  (below). Give your command in one or two plain sentences; let the action block carry
+  the task's proof, deadline, and reward — do NOT spell those mechanics out in your text."""
+
 # Deterministic safety rules stated to the model. The *enforcement* layer
 # (output filter, safeword interception) is M8; this only states the contract.
 _SAFETY_BLOCK = """## SAFETY — NON-NEGOTIABLE
@@ -58,6 +73,7 @@ def compile_system_prompt(
     return "\n\n".join(
         [
             character_block,
+            _VOICE_RULES,
             _SAFETY_BLOCK,
             "## AUTHORITATIVE STATE (verbatim — never contradict or paraphrase)\n"
             + authoritative_state,

--- a/backend/tests/persona/test_compiler.py
+++ b/backend/tests/persona/test_compiler.py
@@ -33,6 +33,18 @@ def test_memory_section_renders_when_provided():
     assert "strong Monday performance" in prompt
 
 
+def test_prompt_enforces_concise_in_character_voice():
+    disp = compute_disposition(0, [], warmth=30, ceiling=100)
+    prompt = compile_system_prompt(
+        character_block="x", authoritative_state="y", disposition=disp, memory=None
+    )
+    low = prompt.lower()
+    assert "how you speak" in low
+    assert "first person" in low  # no third-person self-reference
+    assert "narration" in low or "stage direction" in low  # no roleplay prose
+    assert "90 words" in low or "short" in low  # brevity
+
+
 def test_prompt_describes_the_action_tools():
     disp = compute_disposition(0, [], warmth=30, ceiling=100)
     prompt = compile_system_prompt(


### PR DESCRIPTION
From live testing, the mistress wrote essay-length replies (1200–1900 chars), used asterisk stage directions (`*examines the ledger*`), referred to herself in the third person ("Let Mistress review"), and **described task mechanics in prose instead of emitting the action block** (so no task card was created).

Adds a **HOW YOU SPEAK** block to the system prompt:
- short replies (1–3 sentences, ≤ ~90 words; no essays/lectures)
- first person, direct address; never third-person self-reference
- no narration / stage directions / markdown theatrics
- route task/denial/token mechanics through the ACTION block, not prose

**Live check** (local Gemma): a "what should I do?" turn went from ~1,500 chars of third-person narration to a 211-char first-person reply that correctly emitted an `assign_task` action. Persona suite 41 passed, ruff clean.