### PR TITLE
fix(persona): strengthen tool-use adherence (blunt rule + worked examples)

### DIFF
--- a/backend/app/persona/compiler.py
+++ b/backend/app/persona/compiler.py
@@ -48,7 +48,28 @@ Tools:
 - set_denial_timer — hours (int), reason (str).
 - grant_tokens — amount (int >= 1), reason (str).
 
-Omit the block entirely when you are not acting."""
+ACTING IS THE BLOCK, NOT THE WORDS. Writing "I set a denial timer", "consider yourself
+locked", or "your task is..." does NOTHING on its own — only the block takes effect. If
+you decide to act, you MUST emit the block in the SAME reply. Never tell the user to set a
+timer or assign themselves a task: YOU do it by emitting the block. Omit the block only
+when you are genuinely not acting this turn.
+
+Examples — a short command, then the block:
+
+Lock down for the night, pet. Let the ache sharpen your resolve.
+```action
+{"tool": "set_denial_timer", "hours": 8, "reason": "overnight discipline"}
+```
+
+On your knees and recite your purpose, then report back to me.
+```action
+{"tool": "assign_task", "description": "Kneel and recite your purpose aloud, then report how it felt", "proof": "honor", "merit_reward": 5}
+```
+
+You have earned this much.
+```action
+{"tool": "grant_tokens", "amount": 1, "reason": "honest effort"}
+```"""
 
 
 def compile_system_prompt(

--- a/backend/tests/persona/test_compiler.py
+++ b/backend/tests/persona/test_compiler.py
@@ -54,6 +54,11 @@ def test_prompt_describes_the_action_tools():
     assert "assign_task" in prompt
     assert "set_denial_timer" in prompt
     assert "grant_tokens" in prompt
+    # weak-model adherence: blunt rule + worked examples so she emits the block,
+    # not prose, and never delegates the action to the user
+    assert "only the block takes effect" in prompt.lower()
+    assert "examples" in prompt.lower()
+    assert prompt.count("```action") >= 2  # at least one worked example
 
 
 def test_safety_section_states_nonnegotiable_rules():


### PR DESCRIPTION
Denial timers (and other actions) weren't firing: the mistress narrated "set a denial timer for one hour" in prose and even told the *user* to do it, but never emitted the `set_denial_timer` action block — so nothing was created (`denial_timer` table empty). The pipeline was correct; the small local model just wasn't following the tool protocol.

Strengthens the ACTIONS prompt block:
- a blunt rule — *"acting is the block, not the words; only the block takes effect; never tell the user to do it themselves"*
- one **worked example per tool** (set_denial_timer / assign_task / grant_tokens) — few-shot guidance markedly improves small-model adherence.

**Live check** (local Gemma): "lock me in denial for tonight" now returns a concise reply **plus** a `set_denial_timer` action block, so the timer is actually created. Persona suite 41 passed, ruff clean.