### PR TITLE
fix(chat): normalize action proof value to lower-case

### DIFF
--- a/backend/app/chat/tools.py
+++ b/backend/app/chat/tools.py
@@ -43,7 +43,8 @@ async def execute_action(session: AsyncSession, profile_id: uuid.UUID, action: d
     tool = action.get("tool")
     try:
         if tool == "assign_task":
-            proof = ProofRequirement(action.get("proof", "honor"))
+            # Normalize: capable models often capitalize ("Honor"); the enum is lower-case.
+            proof = ProofRequirement(str(action.get("proof", "honor")).strip().lower())
             deadline = None
             if action.get("deadline_hours"):
                 deadline = datetime.now(timezone.utc) + timedelta(

--- a/backend/tests/chat/test_tools.py
+++ b/backend/tests/chat/test_tools.py
@@ -63,6 +63,16 @@ async def test_execute_grant_tokens_and_denial(session):
     assert len(await econ_svc.active_denial_timers(session, p.id)) == 1
 
 
+async def test_execute_assign_task_normalizes_capitalized_proof(session):
+    # Capable models often write "Honor"/"Timer"; the enum is lower-case.
+    p = await _profile(session)
+    card = await tools.execute_action(
+        session, p.id, {"tool": "assign_task", "description": "kneel", "proof": "Honor"}
+    )
+    assert card.get("proof") == "honor"
+    assert "error" not in card
+
+
 async def test_execute_unknown_or_bad_returns_error_card(session):
     p = await _profile(session)
     assert (await tools.execute_action(session, p.id, {"tool": "nope"}))["error"]


### PR DESCRIPTION
Capable models capitalize enum-ish fields — e.g. `{"tool":"assign_task","proof":"Honor"}` — and `ProofRequirement("Honor")` is case-sensitive, so the action returned an error card and no task was created. Surfaced immediately when testing a 12B/9B model (the tiny model never hit it because it parroted the lowercase example).

Fix: `ProofRequirement(str(proof).strip().lower())`. Added a test (`"Honor"` → `honor`, no error).